### PR TITLE
Rakefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ development database.
 3. Run `bundle exec rake db:migrate` to apply migrations from migrations changes to the schema.db.
 4. Run `bundle exec rake db:seed RAILS_ENV=development` to populate the database `spot_development`.
 
+# Create spots for the coming week
+`bundle exec rake spot:create_spots`
+
 # Create new migrations
 bundle exec rake db:create_migration NAME=name_of_migration_inserted_here
 bundle exec rake db:migrate

--- a/README.md
+++ b/README.md
@@ -48,3 +48,16 @@ development database.
 2. Run `bundle exec rake db:create RAILS_ENV=development`  to create databases.
 3. Run `bundle exec rake db:migrate` to apply migrations from migrations changes to the schema.db.
 4. Run `bundle exec rake db:seed RAILS_ENV=development` to populate the database `spot_development`.
+
+# Create new migrations
+bundle exec rake db:create_migration NAME=name_of_migration_inserted_here
+bundle exec rake db:migrate
+
+# Branches
+We create branches for local dev and push these live to be integrated into `main`. 
+
+git fetch <- this will tell us what's changed
+git pull <- on main branch to get the latest version
+git co -b <branch name> <- to create a new branch
+(work away and commit changes. When ready...)
+git push --set-upstream origin <branch name> <- to push to github

--- a/Rakefile
+++ b/Rakefile
@@ -2,3 +2,19 @@ ENV["SINATRA_ENV"] ||= "development"
 
 require_relative './config/environment'
 require 'sinatra/activerecord/rake'
+
+namespace :spot do
+  desc "Create spots for the coming week for all courses"
+
+  task :create_spots do 
+    monday = Date.parse('Monday')
+    delta = monday > Date.today ? 0 : 7
+    monday += delta
+
+    Course.all.each do |course|
+      next if Spot.exists?(course: course, week_beginning: monday)
+      Spot.create(course: course, week_beginning: monday)
+    end
+
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,8 +3,8 @@ class UsersController < ApplicationController
   # Home page for each user
   get '/index/:username' do
     @user = User.find_by(username: params[:username])
-    @spots = @user.spots.where('session_datetime >= ?', Time.now.utc)
-    @all_spots = Spot.where('session_datetime >= ?', Time.now.utc).order(session_datetime: :asc)
+    @spots = @user.spots.where('week_beginning >= ?', Time.now.utc)
+    @all_spots = Spot.ordered.where('week_beginning >= ?', Time.now.utc)
     @previous_spots = @user.spots.where('session_datetime <= ?', Time.now.utc)
     @courses = Course.all
     erb :index, layout: :layout
@@ -22,9 +22,7 @@ class UsersController < ApplicationController
       course_id: course_id,
       week_beginning: week_beginning,
       session_datetime: session_datetime,
-      student_limit: 5,
-      date_created: DateTime.now
-      }
+      student_limit: 5      }
     Spot.create(@new_spot)
 
     redirect "/index/#{params[:username]}"

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -3,4 +3,6 @@ class Spot < ActiveRecord::Base
   has_many :users, :through => :spot_students
   belongs_to :user
   belongs_to :course
+
+  scope :ordered, -> { includes(:course).order('courses.name') }
 end

--- a/app/views/index.erb
+++ b/app/views/index.erb
@@ -18,7 +18,7 @@
       <ul>
           <% @all_spots.each do |spot| %>
             <li>
-            <p><%= spot.course.name %> at <%= format_time_output(spot.session_datetime.in_time_zone('Eastern Time (US & Canada)')) %> EST.</p>
+            <p><%= spot.course.name %> at <%= format_time_output(spot.session_datetime.in_time_zone('Eastern Time (US & Canada)')) if spot.session_datetime %> EST.</p>
             </li>
           <% end %>
       </ul>

--- a/db/migrate/20210311093810_change_spot_lead_default.rb
+++ b/db/migrate/20210311093810_change_spot_lead_default.rb
@@ -1,0 +1,5 @@
+class ChangeSpotLeadDefault < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :spots, :lead_id, from: 0, to: nil
+  end
+end

--- a/db/migrate/20210311100239_change_spot_to_use_created_at.rb
+++ b/db/migrate/20210311100239_change_spot_to_use_created_at.rb
@@ -1,0 +1,5 @@
+class ChangeSpotToUseCreatedAt < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :spots, :date_created, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_25_040811) do
+ActiveRecord::Schema.define(version: 2021_03_11_093810) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,12 +25,12 @@ ActiveRecord::Schema.define(version: 2021_02_25_040811) do
   end
 
   create_table "spots", force: :cascade do |t|
-    t.integer "lead_id", default: 0
+    t.integer "lead_id"
     t.integer "course_id", null: false
     t.date "week_beginning"
     t.datetime "session_datetime"
     t.integer "student_limit"
-    t.date "date_created", Time.now
+    t.date "date_created"
     t.boolean "archive", default: false
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_11_093810) do
+ActiveRecord::Schema.define(version: 2021_03_11_100239) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2021_03_11_093810) do
     t.date "week_beginning"
     t.datetime "session_datetime"
     t.integer "student_limit"
-    t.date "date_created"
+    t.date "created_at"
     t.boolean "archive", default: false
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,30 @@
 # Pre-populate data for admin roles and pre-determined courses from Launch School
 
+# helpers method and variables
+DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+# Exclude Sunday. Sunday date may appear in the database due to Ruby runs in local time, but
+# is converted to UTC behind the scene (time zone issue). No important issue since
+# data is used for testing only.
+
+def generate_random_day
+  Date.parse(DAYS[rand(0..5)])
+end
+
+def generate_random_hour
+  rand(0..24).hours # Methods hours, days, minutes are supported by 'active_support/all' library
+end
+
+def generate_half_hour
+  (rand(0..100) <= 50 ? 0 : 30).minutes
+end
+
+def generate_random_session_datetime
+  (generate_random_day + generate_random_hour + generate_half_hour).to_datetime
+end
+
+monday = Date.parse('Monday')
+last_thursday = Date.parse('Thursday') - 7.days
+
 # Pre-populate data for admin roles and pre-determined courses from Launch School
 
 courses = [
@@ -49,19 +74,19 @@ end
 # date_created starts on Saturday, week_beginning starts on Sunday, session_datetime starts on Thursday.
 
 spots = [
-  {lead_id: 1, course_id: 1, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:00', student_limit: 5},
-  {lead_id: 1, course_id: 2, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:01', student_limit: 5},
-  {lead_id: 1, course_id: 3, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:02', student_limit: 5},
-  {lead_id: 1, course_id: 2, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:03', student_limit: 5},
-  {lead_id: 2, course_id: 1, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:12', student_limit: 5},
-  {lead_id: 2, course_id: 1, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:09', student_limit: 5},
-  {lead_id: 2, course_id: 3, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:10', student_limit: 5},
-  {lead_id: 2, course_id: 4, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:11', student_limit: 5},
-  {lead_id: 3, course_id: 4, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:00', student_limit: 5},
-  {lead_id: 3, course_id: 3, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:00', student_limit: 5},
-  {lead_id: 1, course_id: 1, week_beginning: '2021-02-28', session_datetime: '2021-03-04 19:00', student_limit: 5, archive: 'true'},
-  {lead_id: 1, course_id: 2, week_beginning: '2021-02-28', session_datetime: '2021-03-04 19:00', student_limit: 5, archive: 'true'},
-  {lead_id: 1, course_id: 3, week_beginning: '2021-02-28', session_datetime: '2021-03-04 19:00', student_limit: 5, archive: 'true'}
+  {lead_id: 1, course_id: 1, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
+  {lead_id: 1, course_id: 2, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
+  {lead_id: 1, course_id: 3, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
+  {lead_id: 1, course_id: 2, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
+  {lead_id: 2, course_id: 1, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
+  {lead_id: 2, course_id: 1, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
+  {lead_id: 2, course_id: 3, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
+  {lead_id: 2, course_id: 4, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
+  {lead_id: 3, course_id: 4, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
+  {lead_id: 3, course_id: 3, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
+  {lead_id: 1, course_id: 1, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday, archive: 'true'},
+  {lead_id: 1, course_id: 2, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday, archive: 'true'},
+  {lead_id: 1, course_id: 3, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday, archive: 'true'}
 ]
 
 spots.each do |spot|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,7 @@ DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
 # data is used for testing only.
 
 def generate_random_day
-  Date.parse(DAYS[rand(0..5)])
+  Date.parse(DAYS[rand(0..5)]) + 7.days
 end
 
 def generate_random_hour
@@ -22,8 +22,15 @@ def generate_random_session_datetime
   (generate_random_day + generate_random_hour + generate_half_hour).to_datetime
 end
 
-monday = Date.parse('Monday')
-last_thursday = Date.parse('Thursday') - 7.days
+def generate_random_archive_day
+  Date.parse(DAYS[rand(0..5)]) - 7.days
+end
+
+def generate_archive_session_datetime
+  (generate_random_archive_day + generate_random_hour + generate_half_hour).to_datetime
+end
+
+next_monday = Date.parse('Monday') + 7.days 
 
 # Pre-populate data for admin roles and pre-determined courses from Launch School
 
@@ -74,19 +81,19 @@ end
 # date_created starts on Saturday, week_beginning starts on Sunday, session_datetime starts on Thursday.
 
 spots = [
-  {lead_id: 1, course_id: 1, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
-  {lead_id: 1, course_id: 2, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
-  {lead_id: 1, course_id: 3, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
-  {lead_id: 1, course_id: 2, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
-  {lead_id: 2, course_id: 1, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
-  {lead_id: 2, course_id: 1, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
-  {lead_id: 2, course_id: 3, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
-  {lead_id: 2, course_id: 4, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
-  {lead_id: 3, course_id: 4, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
-  {lead_id: 3, course_id: 3, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday},
-  {lead_id: 1, course_id: 1, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday, archive: 'true'},
-  {lead_id: 1, course_id: 2, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday, archive: 'true'},
-  {lead_id: 1, course_id: 3, week_beginning: monday, session_datetime: generate_random_session_datetime, student_limit: 5,created_at: last_thursday, archive: 'true'}
+  {lead_id: 1, course_id: 1, week_beginning: next_monday, session_datetime: generate_random_session_datetime, student_limit: 5},
+  {lead_id: 1, course_id: 2, week_beginning: next_monday, session_datetime: generate_random_session_datetime, student_limit: 5},
+  {lead_id: 1, course_id: 3, week_beginning: next_monday, session_datetime: generate_random_session_datetime, student_limit: 5},
+  {lead_id: 1, course_id: 2, week_beginning: next_monday, session_datetime: generate_random_session_datetime, student_limit: 5},
+  {lead_id: 2, course_id: 1, week_beginning: next_monday, session_datetime: generate_random_session_datetime, student_limit: 5},
+  {lead_id: 2, course_id: 1, week_beginning: next_monday, session_datetime: generate_random_session_datetime, student_limit: 5},
+  {lead_id: 2, course_id: 3, week_beginning: next_monday, session_datetime: generate_random_session_datetime, student_limit: 5},
+  {lead_id: 2, course_id: 4, week_beginning: next_monday, session_datetime: generate_random_session_datetime, student_limit: 5},
+  {lead_id: 3, course_id: 4, week_beginning: next_monday, session_datetime: generate_random_session_datetime, student_limit: 5},
+  {lead_id: 3, course_id: 3, week_beginning: next_monday, session_datetime: generate_random_session_datetime, student_limit: 5},
+  {lead_id: 1, course_id: 1, week_beginning: next_monday, session_datetime: generate_archive_session_datetime, student_limit: 5, archive: 'true'},
+  {lead_id: 1, course_id: 2, week_beginning: next_monday, session_datetime: generate_archive_session_datetime, student_limit: 5, archive: 'true'},
+  {lead_id: 1, course_id: 3, week_beginning: next_monday, session_datetime: generate_archive_session_datetime, student_limit: 5, archive: 'true'}
 ]
 
 spots.each do |spot|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,19 +49,19 @@ end
 # date_created starts on Saturday, week_beginning starts on Sunday, session_datetime starts on Thursday.
 
 spots = [
-  {lead_id: 1, course_id: 1, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:00', student_limit: 5, date_created: '2021-03-06'},
-  {lead_id: 1, course_id: 2, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:01', student_limit: 5, date_created: '2021-03-06'},
-  {lead_id: 1, course_id: 3, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:02', student_limit: 5, date_created: '2021-03-06'},
-  {lead_id: 1, course_id: 2, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:03', student_limit: 5, date_created: '2021-03-06'},
-  {lead_id: 2, course_id: 1, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:12', student_limit: 5, date_created: '2021-03-06'},
-  {lead_id: 2, course_id: 1, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:09', student_limit: 5, date_created: '2021-03-06'},
-  {lead_id: 2, course_id: 3, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:10', student_limit: 5, date_created: '2021-03-06'},
-  {lead_id: 2, course_id: 4, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:11', student_limit: 5, date_created: '2021-03-06'},
-  {lead_id: 3, course_id: 4, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:00', student_limit: 5, date_created: '2021-03-06'},
-  {lead_id: 3, course_id: 3, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:00', student_limit: 5, date_created: '2021-03-06'},
-  {lead_id: 1, course_id: 1, week_beginning: '2021-02-28', session_datetime: '2021-03-04 19:00', student_limit: 5, date_created: '2021-02-27', archive: 'true'},
-  {lead_id: 1, course_id: 2, week_beginning: '2021-02-28', session_datetime: '2021-03-04 19:00', student_limit: 5, date_created: '2021-02-27', archive: 'true'},
-  {lead_id: 1, course_id: 3, week_beginning: '2021-02-28', session_datetime: '2021-03-04 19:00', student_limit: 5, date_created: '2021-02-27', archive: 'true'}
+  {lead_id: 1, course_id: 1, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:00', student_limit: 5},
+  {lead_id: 1, course_id: 2, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:01', student_limit: 5},
+  {lead_id: 1, course_id: 3, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:02', student_limit: 5},
+  {lead_id: 1, course_id: 2, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:03', student_limit: 5},
+  {lead_id: 2, course_id: 1, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:12', student_limit: 5},
+  {lead_id: 2, course_id: 1, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:09', student_limit: 5},
+  {lead_id: 2, course_id: 3, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:10', student_limit: 5},
+  {lead_id: 2, course_id: 4, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:11', student_limit: 5},
+  {lead_id: 3, course_id: 4, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:00', student_limit: 5},
+  {lead_id: 3, course_id: 3, week_beginning: '2021-03-07', session_datetime: '2021-03-11 19:00', student_limit: 5},
+  {lead_id: 1, course_id: 1, week_beginning: '2021-02-28', session_datetime: '2021-03-04 19:00', student_limit: 5, archive: 'true'},
+  {lead_id: 1, course_id: 2, week_beginning: '2021-02-28', session_datetime: '2021-03-04 19:00', student_limit: 5, archive: 'true'},
+  {lead_id: 1, course_id: 3, week_beginning: '2021-02-28', session_datetime: '2021-03-04 19:00', student_limit: 5, archive: 'true'}
 ]
 
 spots.each do |spot|


### PR DESCRIPTION
This
 - adds a rakefile to create a week's worth of spots, starting on the coming Monday (`bundle exec rake spot:create_spots`)
 - changes spot database
   - created_at fieldname used, to take advantage of ActiveRecord default behaviour (sets the date by default so we don't have to)
   - removed `0` as default for lead. Is now nil (so we can have spots without leads)
 - Adds a scope in the model to order spots by course name
 - Removes reliance on session_datetime, to allow for spots that don't have times set yet
 - Updates readme to include rakefile info, branch info and migrations info.